### PR TITLE
Prevent certain valid bookmarks from being moved to trash

### DIFF
--- a/src/background/features/CleanBookmarks.ts
+++ b/src/background/features/CleanBookmarks.ts
@@ -36,14 +36,12 @@ const checkBookmarkStatus = (trash: Trash) => {
       })
         .then((response) => {
           const isDeadBookmark =
-            response.status == 400
+            response.status == 404 ||
+            response.status == 410
 
           if (isDeadBookmark) {
             moveToTrash(id, trash.id)
           }
-        })
-        .catch(() => {
-          moveToTrash(id, trash.id)
         })
     })
   })


### PR DESCRIPTION
Closes https://github.com/samueldobbie/remarkable-extension/issues/1

This PR somewhat goes the other way, in that certain dead URLs now won't be detected as being dead; although I'd much rather it have false-negatives than false-positives.